### PR TITLE
Enhance security with a WAF

### DIFF
--- a/src/load_balancer_stack.py
+++ b/src/load_balancer_stack.py
@@ -3,6 +3,7 @@ import aws_cdk as cdk
 from aws_cdk import (
     aws_ec2 as ec2,
     aws_elasticloadbalancingv2 as elbv2,
+    aws_wafv2 as wafv2,
 )
 
 from constructs import Construct
@@ -21,6 +22,65 @@ class LoadBalancerStack(cdk.Stack):
         self.alb = elbv2.ApplicationLoadBalancer(
             self, "AppLoadBalancer", vpc=vpc, internet_facing=True
         )
+
+        # WAF to protect against common web attacks
+        web_acl = wafv2.CfnWebACL(
+            self,
+            "WebAcl",
+            scope="REGIONAL",
+            default_action=wafv2.CfnWebACL.DefaultActionProperty(allow={}),
+            visibility_config=wafv2.CfnWebACL.VisibilityConfigProperty(
+                cloud_watch_metrics_enabled=True,
+                metric_name="WebAclMetrics",
+                sampled_requests_enabled=True,
+            ),
+            rules=[
+                # Rules that provide protection against exploitation of a wide range of vulnerabilities,
+                # including those described in OWASP top 10 publications
+                wafv2.CfnWebACL.RuleProperty(
+                    name="AWSManagedRulesCommonRuleSet",
+                    priority=0,
+                    statement=wafv2.CfnWebACL.StatementProperty(
+                        managed_rule_group_statement=wafv2.CfnWebACL.ManagedRuleGroupStatementProperty(
+                            name="AWSManagedRulesCommonRuleSet",
+                            vendor_name="AWS",
+                        )
+                    ),
+                    override_action=wafv2.CfnWebACL.OverrideActionProperty(none={}),
+                    visibility_config=wafv2.CfnWebACL.VisibilityConfigProperty(
+                        cloud_watch_metrics_enabled=True,
+                        metric_name="AWSManagedRulesCommonRuleSet",
+                        sampled_requests_enabled=True,
+                    ),
+                ),
+                # Rules to block request patterns that are known to be invalid and are associated with
+                # exploitation or discovery of vulnerabilities.
+                wafv2.CfnWebACL.RuleProperty(
+                    name="AWSManagedRulesKnownBadInputsRuleSet",
+                    priority=1,
+                    statement=wafv2.CfnWebACL.StatementProperty(
+                        managed_rule_group_statement=wafv2.CfnWebACL.ManagedRuleGroupStatementProperty(
+                            vendor_name="AWS",
+                            name="AWSManagedRulesKnownBadInputsRuleSet",
+                        )
+                    ),
+                    override_action=wafv2.CfnWebACL.OverrideActionProperty(none={}),
+                    visibility_config=wafv2.CfnWebACL.VisibilityConfigProperty(
+                        sampled_requests_enabled=True,
+                        cloud_watch_metrics_enabled=True,
+                        metric_name="AWSManagedRulesKnownBadInputsRuleSet",
+                    ),
+                ),
+            ],
+        )
+
+        wafv2.CfnWebACLAssociation(
+            self,
+            "WeAclAssociation",
+            resource_arn=self.alb.load_balancer_arn,
+            web_acl_arn=web_acl.attr_arn,
+        )
+
         cdk.CfnOutput(
             self,
             "LoadBalancerDns",


### PR DESCRIPTION
Web application firewall for agora app, enabled with the AWS managed Baseline core rule set[1] to protect again OWASP top 10 vunerablities[2]. Additional rules[3] can be added by updating the WebAcl rules object.

Note: AWS CDK Level 2 construct is not available for WAFv2 yet therefore we need to use level 1 construct

[1] https://docs.aws.amazon.com/waf/latest/developerguide/aws-managed-rule-groups-baseline.html#aws-managed-rule-groups-baseline-crs
[2] https://owasp.org/www-project-top-ten/
[3] https://docs.aws.amazon.com/waf/latest/developerguide/aws-managed-rule-groups-list.html

