### PR TITLE
Refactor github action

### DIFF
--- a/.github/workflows/deploy-dev.yaml
+++ b/.github/workflows/deploy-dev.yaml
@@ -1,18 +1,17 @@
 name: deploy-dev
 
 on:
-  workflow_run:
-    workflows:
-      - check
-    types:
-      - completed
-    branches:
-      - dev
+  push:
+    branches: ['dev']
 
 jobs:
+  test:
+    uses: ./.github/workflows/test.yaml
+    with:
+      environment: dev
   aws-deploy:
     uses: "./.github/workflows/aws-deploy.yaml"
     with:
-      role-to-assume: "arn:aws:iam::XXXXXXXX:role/sagebase-github-oidc-myapp-infra"
+      role-to-assume: "arn:aws:iam::607346494281:role/sagebase-github-oidc-agora-infra-v3"
       role-session-name: ${{ github.repository_owner }}-${{ github.event.repository.name }}-${{ github.run_id }}
       environment: dev

--- a/.github/workflows/deploy-dev.yaml
+++ b/.github/workflows/deploy-dev.yaml
@@ -12,6 +12,6 @@ jobs:
   aws-deploy:
     uses: "./.github/workflows/aws-deploy.yaml"
     with:
-      role-to-assume: "arn:aws:iam::607346494281:role/sagebase-github-oidc-agora-infra-v3"
+      role-to-assume: "arn:aws:iam::XXXXXXXX:role/sagebase-github-oidc-myapp-infra"
       role-session-name: ${{ github.repository_owner }}-${{ github.event.repository.name }}-${{ github.run_id }}
       environment: dev

--- a/.github/workflows/deploy-prod.yaml
+++ b/.github/workflows/deploy-prod.yaml
@@ -1,18 +1,17 @@
 name: deploy-prod
 
 on:
-  workflow_run:
-    workflows:
-      - check
-    types:
-      - completed
-    branches:
-      - prod
+  push:
+    branches: ['prod']
 
 jobs:
+  test:
+    uses: ./.github/workflows/test.yaml
+    with:
+      environment: prod
   aws-deploy:
     uses: "./.github/workflows/aws-deploy.yaml"
     with:
-      role-to-assume: "arn:aws:iam::XXXXXXXX:role/sagebase-github-oidc-myapp-infra"
+      role-to-assume: "arn:aws:iam::681175625864:role/sagebase-github-oidc-agora-infra-v3"
       role-session-name: ${{ github.repository_owner }}-${{ github.event.repository.name }}-${{ github.run_id }}
       environment: prod

--- a/.github/workflows/deploy-prod.yaml
+++ b/.github/workflows/deploy-prod.yaml
@@ -12,6 +12,6 @@ jobs:
   aws-deploy:
     uses: "./.github/workflows/aws-deploy.yaml"
     with:
-      role-to-assume: "arn:aws:iam::681175625864:role/sagebase-github-oidc-agora-infra-v3"
+      role-to-assume: "arn:aws:iam::XXXXXXXX:role/sagebase-github-oidc-myapp-infra"
       role-session-name: ${{ github.repository_owner }}-${{ github.event.repository.name }}-${{ github.run_id }}
       environment: prod

--- a/.github/workflows/deploy-stage.yaml
+++ b/.github/workflows/deploy-stage.yaml
@@ -12,6 +12,6 @@ jobs:
   aws-deploy:
     uses: "./.github/workflows/aws-deploy.yaml"
     with:
-      role-to-assume: "arn:aws:iam::681175625864:role/sagebase-github-oidc-agora-infra-v3"
+      role-to-assume: "arn:aws:iam::XXXXXXXX:role/sagebase-github-oidc-myapp-infra"
       role-session-name: ${{ github.repository_owner }}-${{ github.event.repository.name }}-${{ github.run_id }}
       environment: stage

--- a/.github/workflows/deploy-stage.yaml
+++ b/.github/workflows/deploy-stage.yaml
@@ -1,18 +1,17 @@
 name: deploy-stage
 
 on:
-  workflow_run:
-    workflows:
-      - check
-    types:
-      - completed
-    branches:
-      - stage
+  push:
+    branches: ['stage']
 
 jobs:
+  test:
+    uses: ./.github/workflows/test.yaml
+    with:
+      environment: stage
   aws-deploy:
     uses: "./.github/workflows/aws-deploy.yaml"
     with:
-      role-to-assume: "arn:aws:iam::XXXXXXXX:role/sagebase-github-oidc-myapp-infra"
+      role-to-assume: "arn:aws:iam::681175625864:role/sagebase-github-oidc-agora-infra-v3"
       role-session-name: ${{ github.repository_owner }}-${{ github.event.repository.name }}-${{ github.run_id }}
       environment: stage

--- a/.github/workflows/pr-check.yaml
+++ b/.github/workflows/pr-check.yaml
@@ -1,0 +1,11 @@
+name: pr-check
+
+on:
+  pull_request:
+    branches: ['*']
+
+jobs:
+  test:
+    uses: ./.github/workflows/test.yaml
+    with:
+      environment: dev

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -1,11 +1,11 @@
-name: check
+name: test
 
 on:
-  pull_request:
-    branches: ['*']
-  push:
-    branches: ['*']
-
+  workflow_call:
+    inputs:
+      environment:
+        required: true
+        type: string
 jobs:
   unit-tests:
     runs-on: ubuntu-latest
@@ -26,7 +26,7 @@ jobs:
       - name: Generate cloudformation
         uses: youyo/aws-cdk-github-actions@v2
         env:
-          ENV: dev
+          ENV: ${{ inputs.environment }}
         with:
           cdk_subcommand: 'synth'
           actions_comment: false


### PR DESCRIPTION
When triggering jobs with workflow_run the default git ref to fetch is the
default branch[1], causing all deploys to use the dev branch. We want the
workflow to checkout the branch that trigger the event. The github
community suggested solution is to change workflow_run to workflow_call[2]

[1] https://docs.github.com/en/actions/writing-workflows/choosing-when-your-workflow-runs/events-that-trigger-workflows#workflow_run
[2] https://github.com/orgs/community/discussions/72097#discussioncomment-7376117

