### PR TITLE
Allow setting container cpu and memory

### DIFF
--- a/README.md
+++ b/README.md
@@ -148,9 +148,10 @@ when creating a `ServiceProp` object. You'll be creating a list of `ServiceSecre
 from src.service_props import ServiceProps, ServiceSecret
 
 app_service_props = ServiceProps(
+    ecs_task_cpu=256,
+    ecs_task_memory=512,
     container_name="app",
     container_port=443,
-    container_memory=1024,
     container_location="ghcr.io/sage-bionetworks/app:v1.0",
     container_secrets=[
         ServiceSecret(

--- a/app.py
+++ b/app.py
@@ -76,11 +76,11 @@ load_balancer_stack = LoadBalancerStack(
 )
 
 app_props = ServiceProps(
+    ecs_task_cpu=256,
+    ecs_task_memory=512,
     container_name="my-app",
     container_location=f"ghcr.io/sage-bionetworks/my-app:{app_version}",
     container_port=80,
-    container_cpu=256,
-    container_memory=512,
     container_env_vars={
         "APP_VERSION": f"{app_version}",
     },

--- a/src/service_props.py
+++ b/src/service_props.py
@@ -53,8 +53,8 @@ class ServiceProps:
       supports "path://" for building container from local (i.e. path://docker/MyContainer)
       supports docker registry references (i.e. ghcr.io/sage-bionetworks/app:latest)
     container_port: the container application port
-    container_cpu: the container application CPU in millicores (i.e. 1024 = 1 vCPU)
-    container_memory: the container application memory
+    ecs_task_cpu: the ECS task CPU in millicores (i.e. 1024 = 1 vCPU)
+    ecs_task_memory: the ECS task memory
     container_env_vars: a json dictionary of environment variables to pass into the container
       i.e. {"EnvA": "EnvValueA", "EnvB": "EnvValueB"}
     container_secrets: List of `ServiceSecret` resources to pull from AWS secrets manager
@@ -70,11 +70,11 @@ class ServiceProps:
         container_name: str,
         container_location: str,
         container_port: int,
-        container_cpu: int = 256,
-        container_memory: int = 512,
         container_env_vars: dict = None,
         container_secrets: List[ServiceSecret] = None,
         container_volumes: List[ContainerVolume] = None,
+        ecs_task_cpu: int = 256,
+        ecs_task_memory: int = 512,
         auto_scale_min_capacity: int = 1,
         auto_scale_max_capacity: int = 1,
         container_command: Optional[Sequence[str]] = None,
@@ -82,8 +82,8 @@ class ServiceProps:
     ) -> None:
         self.container_name = container_name
         self.container_port = container_port
-        self.container_cpu = container_cpu
-        self.container_memory = container_memory
+        self.ecs_task_cpu = ecs_task_cpu
+        self.ecs_task_memory = ecs_task_memory
         if CONTAINER_LOCATION_PATH_ID in container_location:
             container_location = container_location.removeprefix(
                 CONTAINER_LOCATION_PATH_ID

--- a/src/service_stack.py
+++ b/src/service_stack.py
@@ -84,8 +84,8 @@ class ServiceStack(cdk.Stack):
         self.task_definition = ecs.FargateTaskDefinition(
             self,
             "TaskDef",
-            cpu=props.container_cpu,
-            memory_limit_mib=props.container_memory,
+            cpu=props.ecs_task_cpu,
+            memory_limit_mib=props.ecs_task_memory,
             task_role=task_role,
             execution_role=execution_role,
         )

--- a/tests/unit/test_service_stack.py
+++ b/tests/unit/test_service_stack.py
@@ -19,8 +19,8 @@ def test_service_stack_created():
         container_name="app",
         container_location="ghcr.io/sage-bionetworks/app:1.0",
         container_port=8010,
-        container_cpu=256,
-        container_memory=512,
+        ecs_task_cpu=256,
+        ecs_task_memory=512,
         container_secrets=[
             ServiceSecret(
                 secret_name="/app/secret",


### PR DESCRIPTION
Parameterize container CPU and memory to allow users to right size containers.  The values need to be a matched pair[1]

When using fargate the memory and cpu are required at the ECS task level instead of at the container level[2].  Refactored to set memory and cpu at the task level and removed them from container level.

[1] https://docs.aws.amazon.com/AmazonECS/latest/developerguide/task_definition_parameters.html
[2] https://docs.aws.amazon.com/AWSCloudFormation/latest/TemplateReference/aws-resource-ecs-taskdefinition.html