### PR TITLE
[IT-4961] Add opt-in monitoring stack for ECS services

### DIFF
--- a/README.md
+++ b/README.md
@@ -318,11 +318,13 @@ classDiagram
 
 ### Enabling Monitoring
 
-Add a `MONITORING` section to your environment config file (e.g., `config/dev.yaml`).
-At minimum, set `notification_email` to activate the monitoring stack:
+Default monitoring settings (disabled) live in `config/base.yaml`. To activate,
+override `enabled` and `notification_email` in your environment config:
 
 ```yaml
+# config/dev.yaml
 MONITORING:
+  enabled: true
   notification_email: "team@example.com"
 ```
 
@@ -334,11 +336,12 @@ This creates:
 
 ### Full Configuration Reference
 
-All fields except `notification_email` are optional:
+All fields except `enabled` and `notification_email` have defaults in `config/base.yaml`:
 
 ```yaml
 MONITORING:
-  notification_email: "team@example.com"       # Required - enables the monitoring stack
+  enabled: true                                # Required - activates the monitoring stack
+  notification_email: "team@example.com"       # Required - SNS email subscription
   slack_webhook_url: ""                         # Optional - Slack incoming webhook URL for alerts
   enable_dashboard: true                        # Optional - creates a CloudWatch dashboard (default: true)
   alarms:                                       # Optional - override default alarm thresholds
@@ -357,6 +360,7 @@ For example, to only tighten the CPU threshold for production:
 ```yaml
 # config/prod.yaml
 MONITORING:
+  enabled: true
   notification_email: "oncall@example.com"
   alarms:
     ecs_cpu_threshold: 70

--- a/README.md
+++ b/README.md
@@ -223,6 +223,201 @@ TargetHostName: !CopyValue [!Sub 'app-dev-load-balancer-dns', !Ref DnTDevAccount
 > Setting up the DNS cname should be done at the very end of this infra setup
 
 
+## Monitoring (Optional)
+
+This template includes an opt-in monitoring stack that provides CloudWatch alarms,
+SNS notifications, and a CloudWatch dashboard for your ECS service. **No monitoring
+resources are created unless you explicitly configure them.**
+
+### How It Fits Together
+
+When monitoring is enabled, the template creates a fifth CloudFormation stack
+(`app-{env}-monitoring`) that references resources from the other stacks. It also
+enables [ECS Container Insights (Enhanced)](https://docs.aws.amazon.com/AmazonCloudWatch/latest/monitoring/ContainerInsights.html)
+on the ECS cluster, which is required for the RunningTaskCount metric.
+
+```mermaid
+graph TB
+    subgraph "Configuration"
+        YAML["Environment YAML<br/>(e.g. dev.yaml)"]
+    end
+
+    subgraph "app-{env}-ecs"
+        CLUSTER["ECS Cluster<br/>(Container Insights: Enhanced)"]
+    end
+
+    subgraph "app-{env}-app"
+        ECS["ECS Fargate Service"]
+        TG["ALB Target Group"]
+    end
+
+    subgraph "app-{env}-load-balancer"
+        ALB["Application Load Balancer"]
+    end
+
+    subgraph "app-{env}-monitoring (new)"
+        SNS["SNS Topic"]
+        EMAIL["Email Subscription"]
+        SLACK["Slack Lambda<br/>(optional)"]
+        ALARMS["CloudWatch Alarms (7)"]
+        DASH["CloudWatch Dashboard<br/>(optional)"]
+    end
+
+    YAML -->|MONITORING config present| CLUSTER
+    YAML -->|MONITORING config| SNS
+    SNS --> EMAIL
+    SNS --> SLACK
+    ALARMS -->|alarm action| SNS
+    ECS -->|CPU, Memory metrics| ALARMS
+    ALB -->|5xx, P99 latency metrics| ALARMS
+    TG -->|Healthy/Unhealthy host metrics| ALARMS
+    CLUSTER -->|Running task count| ALARMS
+    ECS --> DASH
+    ALB --> DASH
+    TG --> DASH
+```
+
+> [!NOTE]
+> The monitoring stack is designed for `LoadBalancedServiceStack` (the default
+> in this template). It requires an ALB target group for the healthy/unhealthy
+> host alarms. If you modify the template to use the base `ServiceStack` without
+> an ALB, you will need to adapt the monitoring stack accordingly.
+
+> [!NOTE]
+> Enabling monitoring turns on
+> [ECS Container Insights (Enhanced)](https://docs.aws.amazon.com/AmazonCloudWatch/latest/monitoring/ContainerInsights.html)
+> on the ECS cluster. This adds a small cost (~$0.50/container/month) but is
+> required for the RunningTaskCount metric and provides richer observability.
+
+### Alarm Coverage
+
+```mermaid
+classDiagram
+    class ECSAlarms {
+        +CPU Utilization High >=80%
+        +Memory Utilization High >=80%
+        +Running Tasks Zero ~lt~1
+    }
+    class ALBAlarms {
+        +5xx Error Count >=10 per 5min
+        +P99 Latency >=5s
+    }
+    class TargetGroupAlarms {
+        +Unhealthy Host Count >=1
+        +Healthy Host Count ~lt~1
+    }
+    class SNSTopic {
+        +Email Subscription
+        +Slack Lambda (optional)
+    }
+
+    ECSAlarms --> SNSTopic : alarm action
+    ALBAlarms --> SNSTopic : alarm action
+    TargetGroupAlarms --> SNSTopic : alarm action
+```
+
+### Enabling Monitoring
+
+Add a `MONITORING` section to your environment config file (e.g., `config/dev.yaml`).
+At minimum, set `notification_email` to activate the monitoring stack:
+
+```yaml
+MONITORING:
+  notification_email: "team@example.com"
+```
+
+This creates:
+- An SNS topic with an email subscription (you must confirm the subscription via email)
+- 7 CloudWatch alarms with sensible default thresholds
+- A CloudWatch dashboard with ECS, ALB, and health widgets
+- ECS Container Insights (Enhanced) on the cluster
+
+### Full Configuration Reference
+
+All fields except `notification_email` are optional:
+
+```yaml
+MONITORING:
+  notification_email: "team@example.com"       # Required - enables the monitoring stack
+  slack_webhook_url: ""                         # Optional - Slack incoming webhook URL for alerts
+  enable_dashboard: true                        # Optional - creates a CloudWatch dashboard (default: true)
+  alarms:                                       # Optional - override default alarm thresholds
+    ecs_cpu_threshold: 80                       # CPU utilization % (default: 80)
+    ecs_memory_threshold: 80                    # Memory utilization % (default: 80)
+    alb_5xx_threshold: 10                       # 5xx error count per 5min (default: 10)
+    alb_p99_latency_threshold: 5                # P99 response time in seconds (default: 5)
+    unhealthy_host_threshold: 1                 # Unhealthy host count to trigger alarm (default: 1)
+    healthy_host_min: 1                         # Minimum healthy hosts before alarm (default: 1)
+    running_task_min: 1                         # Minimum running tasks before alarm (default: 1)
+```
+
+You can override individual alarm thresholds without specifying all of them.
+For example, to only tighten the CPU threshold for production:
+
+```yaml
+# config/prod.yaml
+MONITORING:
+  notification_email: "oncall@example.com"
+  alarms:
+    ecs_cpu_threshold: 70
+```
+
+### Notification Flow
+
+```mermaid
+sequenceDiagram
+    participant CW as CloudWatch Metric
+    participant AL as CloudWatch Alarm
+    participant SNS as SNS Topic
+    participant EM as Email
+    participant SL as Slack Lambda
+
+    CW->>AL: Metric breaches threshold
+    AL->>SNS: Publish alarm notification
+    SNS->>EM: Send email to notification_email
+    opt slack_webhook_url configured
+        SNS->>SL: Invoke Lambda
+        SL->>SL: POST to Slack webhook
+    end
+    Note over CW,AL: When metric recovers
+    CW->>AL: Metric returns to normal
+    AL->>SNS: Publish OK notification
+    SNS->>EM: Send recovery email
+```
+
+> [!NOTE]
+> After deployment, you must confirm the SNS email subscription by clicking the
+> link in the confirmation email sent to `notification_email`. Until confirmed,
+> no email alerts will be delivered.
+
+### Dashboard
+
+When enabled (default), the CloudWatch dashboard provides three sections:
+
+| Section | Widgets |
+|---------|---------|
+| **ECS Service** | CPU utilization, Memory utilization, Running task count |
+| **Load Balancer** | Requests & errors (4xx/5xx), Target response time (p50/p90/p99) |
+| **Health** | Healthy/unhealthy host count, Active connections, Running tasks alarm |
+
+After deployment, the dashboard URL is printed as a CloudFormation output.
+You can also find it in the AWS Console under CloudFormation > Stacks >
+`app-{env}-monitoring` > Outputs > `DashboardUrl`.
+
+### Disabling Monitoring
+
+To disable monitoring, remove or comment out the `MONITORING` section
+from your environment config file. On the next deployment, you can delete the
+monitoring stack:
+
+```console
+cdk destroy app-{env}-monitoring --context env={env}
+```
+
+> [!NOTE]
+> Removing the `MONITORING` config also disables Container Insights on the ECS
+> cluster on the next deploy, removing its associated cost.
+
 ## Debugging
 
 Generally CDK deployments will create cloudformation events during a CDK deploy.

--- a/app.py
+++ b/app.py
@@ -2,6 +2,7 @@ import aws_cdk as cdk
 
 from src.ecs_stack import EcsStack
 from src.load_balancer_stack import LoadBalancerStack
+from src.monitoring_stack import MonitoringStack
 from src.network_stack import NetworkStack
 from src.service_props import ServiceProps
 from src.service_stack import LoadBalancedServiceStack
@@ -14,6 +15,7 @@ STACK_NAME_PREFIX = f"app-{env_name}"
 FQDN = config["FQDN"]
 TAGS = config["TAGS"]
 APP_VERSION = "latest"
+MONITORING_CONFIG = config.get("MONITORING", {})
 
 # recursively apply tags to all stack resources
 if TAGS:
@@ -31,6 +33,7 @@ ecs_stack = EcsStack(
     construct_id=f"{STACK_NAME_PREFIX}-ecs",
     vpc=network_stack.vpc,
     namespace=FQDN,
+    container_insights=bool(MONITORING_CONFIG.get("notification_email")),
 )
 
 # From AWS docs https://docs.aws.amazon.com/AmazonECS/latest/developerguide/service-connect-concepts-deploy.html
@@ -63,5 +66,17 @@ app_stack = LoadBalancedServiceStack(
     props=app_props,
     load_balancer=load_balancer_stack.alb,
 )
+
+if MONITORING_CONFIG.get("notification_email"):
+    monitoring_stack = MonitoringStack(
+        scope=cdk_app,
+        construct_id=f"{STACK_NAME_PREFIX}-monitoring",
+        service=app_stack.service,
+        cluster=ecs_stack.cluster,
+        load_balancer=load_balancer_stack.alb,
+        target_group=app_stack.target_group,
+        monitoring_config=MONITORING_CONFIG,
+    )
+    monitoring_stack.add_dependency(app_stack)
 
 cdk_app.synth()

--- a/app.py
+++ b/app.py
@@ -33,7 +33,7 @@ ecs_stack = EcsStack(
     construct_id=f"{STACK_NAME_PREFIX}-ecs",
     vpc=network_stack.vpc,
     namespace=FQDN,
-    container_insights=bool(MONITORING_CONFIG.get("notification_email")),
+    container_insights=bool(MONITORING_CONFIG.get("enabled", False)),
 )
 
 # From AWS docs https://docs.aws.amazon.com/AmazonECS/latest/developerguide/service-connect-concepts-deploy.html
@@ -67,7 +67,7 @@ app_stack = LoadBalancedServiceStack(
     load_balancer=load_balancer_stack.alb,
 )
 
-if MONITORING_CONFIG.get("notification_email"):
+if MONITORING_CONFIG.get("enabled", False):
     monitoring_stack = MonitoringStack(
         scope=cdk_app,
         construct_id=f"{STACK_NAME_PREFIX}-monitoring",

--- a/config/base.yaml
+++ b/config/base.yaml
@@ -1,2 +1,18 @@
 TAGS:
   CostCenter: NO PROGRAM / 000000
+
+# Monitoring defaults — override in environment configs to enable.
+# Set enabled: true and notification_email in your env config to activate.
+MONITORING:
+  enabled: false
+  notification_email: ""
+  slack_webhook_url: ""
+  enable_dashboard: true
+  alarms:
+    ecs_cpu_threshold: 80
+    ecs_memory_threshold: 80
+    alb_5xx_threshold: 10
+    alb_p99_latency_threshold: 5
+    unhealthy_host_threshold: 1
+    healthy_host_min: 1
+    running_task_min: 1

--- a/config/dev.yaml
+++ b/config/dev.yaml
@@ -6,6 +6,10 @@ FQDN: dev.mydomain.io
 #   arn:aws:acm:us-east-1:XXXXXXXXX:certificate/e8093404-7db1-4042-90d0-01eb5bde1ffc
 
 # Uncomment to enable monitoring (defaults are in base.yaml).
+# Override specific thresholds as needed — defaults are in base.yaml.
 # MONITORING:
 #   enabled: true
 #   notification_email: "team-dev@example.com"
+#   alarms:
+#     ecs_cpu_threshold: 90
+#     ecs_memory_threshold: 90

--- a/config/dev.yaml
+++ b/config/dev.yaml
@@ -5,17 +5,7 @@ FQDN: dev.mydomain.io
 # CERTIFICATE_ARN: >-
 #   arn:aws:acm:us-east-1:XXXXXXXXX:certificate/e8093404-7db1-4042-90d0-01eb5bde1ffc
 
-# Uncomment to enable monitoring (CloudWatch alarms, dashboard, SNS notifications).
-# At minimum, set notification_email to activate the monitoring stack.
+# Uncomment to enable monitoring (defaults are in base.yaml).
 # MONITORING:
-#   notification_email: "team-dev@example.com"   # Required - enables the monitoring stack
-#   slack_webhook_url: ""                         # Optional - Slack incoming webhook for alerts
-#   enable_dashboard: true                        # Optional - creates a CloudWatch dashboard (default: true)
-#   alarms:                                       # Optional - override default thresholds
-#     ecs_cpu_threshold: 80                       # CPU utilization % (default: 80)
-#     ecs_memory_threshold: 80                    # Memory utilization % (default: 80)
-#     alb_5xx_threshold: 10                       # 5xx count per 5min (default: 10)
-#     alb_p99_latency_threshold: 5                # P99 latency in seconds (default: 5)
-#     unhealthy_host_threshold: 1                 # Unhealthy host count (default: 1)
-#     healthy_host_min: 1                         # Min healthy hosts (default: 1)
-#     running_task_min: 1                         # Min running tasks (default: 1)
+#   enabled: true
+#   notification_email: "team-dev@example.com"

--- a/config/dev.yaml
+++ b/config/dev.yaml
@@ -4,3 +4,18 @@ FQDN: dev.mydomain.io
 # Optional
 # CERTIFICATE_ARN: >-
 #   arn:aws:acm:us-east-1:XXXXXXXXX:certificate/e8093404-7db1-4042-90d0-01eb5bde1ffc
+
+# Uncomment to enable monitoring (CloudWatch alarms, dashboard, SNS notifications).
+# At minimum, set notification_email to activate the monitoring stack.
+# MONITORING:
+#   notification_email: "team-dev@example.com"   # Required - enables the monitoring stack
+#   slack_webhook_url: ""                         # Optional - Slack incoming webhook for alerts
+#   enable_dashboard: true                        # Optional - creates a CloudWatch dashboard (default: true)
+#   alarms:                                       # Optional - override default thresholds
+#     ecs_cpu_threshold: 80                       # CPU utilization % (default: 80)
+#     ecs_memory_threshold: 80                    # Memory utilization % (default: 80)
+#     alb_5xx_threshold: 10                       # 5xx count per 5min (default: 10)
+#     alb_p99_latency_threshold: 5                # P99 latency in seconds (default: 5)
+#     unhealthy_host_threshold: 1                 # Unhealthy host count (default: 1)
+#     healthy_host_min: 1                         # Min healthy hosts (default: 1)
+#     running_task_min: 1                         # Min running tasks (default: 1)

--- a/config/prod.yaml
+++ b/config/prod.yaml
@@ -5,17 +5,11 @@ FQDN: prod.mydomain.io
 # CERTIFICATE_ARN: >-
 #  arn:aws:acm:us-east-1:XXXXXXXXX:certificate/69b3ba97-b382-4648-8f94-a250b77b4994
 
-# Uncomment to enable monitoring (CloudWatch alarms, dashboard, SNS notifications).
-# At minimum, set notification_email to activate the monitoring stack.
+# Uncomment to enable monitoring (defaults are in base.yaml).
+# Override specific thresholds as needed — defaults are in base.yaml.
 # MONITORING:
-#   notification_email: "oncall@example.com"       # Required - enables the monitoring stack
-#   slack_webhook_url: ""                           # Optional - Slack incoming webhook for alerts
-#   enable_dashboard: true                          # Optional - creates a CloudWatch dashboard (default: true)
-#   alarms:                                         # Optional - override default thresholds
-#     ecs_cpu_threshold: 80                         # CPU utilization % (default: 80)
-#     ecs_memory_threshold: 80                      # Memory utilization % (default: 80)
-#     alb_5xx_threshold: 10                         # 5xx count per 5min (default: 10)
-#     alb_p99_latency_threshold: 5                  # P99 latency in seconds (default: 5)
-#     unhealthy_host_threshold: 1                   # Unhealthy host count (default: 1)
-#     healthy_host_min: 1                           # Min healthy hosts (default: 1)
-#     running_task_min: 1                           # Min running tasks (default: 1)
+#   enabled: true
+#   notification_email: "oncall@example.com"
+#   alarms:
+#     ecs_cpu_threshold: 70
+#     ecs_memory_threshold: 70

--- a/config/prod.yaml
+++ b/config/prod.yaml
@@ -4,3 +4,18 @@ FQDN: prod.mydomain.io
 # Optional
 # CERTIFICATE_ARN: >-
 #  arn:aws:acm:us-east-1:XXXXXXXXX:certificate/69b3ba97-b382-4648-8f94-a250b77b4994
+
+# Uncomment to enable monitoring (CloudWatch alarms, dashboard, SNS notifications).
+# At minimum, set notification_email to activate the monitoring stack.
+# MONITORING:
+#   notification_email: "oncall@example.com"       # Required - enables the monitoring stack
+#   slack_webhook_url: ""                           # Optional - Slack incoming webhook for alerts
+#   enable_dashboard: true                          # Optional - creates a CloudWatch dashboard (default: true)
+#   alarms:                                         # Optional - override default thresholds
+#     ecs_cpu_threshold: 80                         # CPU utilization % (default: 80)
+#     ecs_memory_threshold: 80                      # Memory utilization % (default: 80)
+#     alb_5xx_threshold: 10                         # 5xx count per 5min (default: 10)
+#     alb_p99_latency_threshold: 5                  # P99 latency in seconds (default: 5)
+#     unhealthy_host_threshold: 1                   # Unhealthy host count (default: 1)
+#     healthy_host_min: 1                           # Min healthy hosts (default: 1)
+#     running_task_min: 1                           # Min running tasks (default: 1)

--- a/config/prod.yaml
+++ b/config/prod.yaml
@@ -10,3 +10,6 @@ FQDN: prod.mydomain.io
 # MONITORING:
 #   enabled: true
 #   notification_email: "oncall@example.com"
+#   alarms:
+#     ecs_cpu_threshold: 70
+#     ecs_memory_threshold: 70

--- a/config/prod.yaml
+++ b/config/prod.yaml
@@ -10,6 +10,3 @@ FQDN: prod.mydomain.io
 # MONITORING:
 #   enabled: true
 #   notification_email: "oncall@example.com"
-#   alarms:
-#     ecs_cpu_threshold: 70
-#     ecs_memory_threshold: 70

--- a/config/stage.yaml
+++ b/config/stage.yaml
@@ -4,3 +4,18 @@ FQDN: stage.mydomain.io
 # Optional
 # CERTIFICATE_ARN: >-
 #   arn:aws:acm:us-east-1:XXXXXXXXX:certificate/69b3ba97-b382-4648-8f94-a250b77b4994
+
+# Uncomment to enable monitoring (CloudWatch alarms, dashboard, SNS notifications).
+# At minimum, set notification_email to activate the monitoring stack.
+# MONITORING:
+#   notification_email: "team-stage@example.com"  # Required - enables the monitoring stack
+#   slack_webhook_url: ""                          # Optional - Slack incoming webhook for alerts
+#   enable_dashboard: true                         # Optional - creates a CloudWatch dashboard (default: true)
+#   alarms:                                        # Optional - override default thresholds
+#     ecs_cpu_threshold: 80                        # CPU utilization % (default: 80)
+#     ecs_memory_threshold: 80                     # Memory utilization % (default: 80)
+#     alb_5xx_threshold: 10                        # 5xx count per 5min (default: 10)
+#     alb_p99_latency_threshold: 5                 # P99 latency in seconds (default: 5)
+#     unhealthy_host_threshold: 1                  # Unhealthy host count (default: 1)
+#     healthy_host_min: 1                          # Min healthy hosts (default: 1)
+#     running_task_min: 1                          # Min running tasks (default: 1)

--- a/config/stage.yaml
+++ b/config/stage.yaml
@@ -5,17 +5,7 @@ FQDN: stage.mydomain.io
 # CERTIFICATE_ARN: >-
 #   arn:aws:acm:us-east-1:XXXXXXXXX:certificate/69b3ba97-b382-4648-8f94-a250b77b4994
 
-# Uncomment to enable monitoring (CloudWatch alarms, dashboard, SNS notifications).
-# At minimum, set notification_email to activate the monitoring stack.
+# Uncomment to enable monitoring (defaults are in base.yaml).
 # MONITORING:
-#   notification_email: "team-stage@example.com"  # Required - enables the monitoring stack
-#   slack_webhook_url: ""                          # Optional - Slack incoming webhook for alerts
-#   enable_dashboard: true                         # Optional - creates a CloudWatch dashboard (default: true)
-#   alarms:                                        # Optional - override default thresholds
-#     ecs_cpu_threshold: 80                        # CPU utilization % (default: 80)
-#     ecs_memory_threshold: 80                     # Memory utilization % (default: 80)
-#     alb_5xx_threshold: 10                        # 5xx count per 5min (default: 10)
-#     alb_p99_latency_threshold: 5                 # P99 latency in seconds (default: 5)
-#     unhealthy_host_threshold: 1                  # Unhealthy host count (default: 1)
-#     healthy_host_min: 1                          # Min healthy hosts (default: 1)
-#     running_task_min: 1                          # Min running tasks (default: 1)
+#   enabled: true
+#   notification_email: "team-stage@example.com"

--- a/config/stage.yaml
+++ b/config/stage.yaml
@@ -6,6 +6,10 @@ FQDN: stage.mydomain.io
 #   arn:aws:acm:us-east-1:XXXXXXXXX:certificate/69b3ba97-b382-4648-8f94-a250b77b4994
 
 # Uncomment to enable monitoring (defaults are in base.yaml).
+# Override specific thresholds as needed — defaults are in base.yaml.
 # MONITORING:
 #   enabled: true
 #   notification_email: "team-stage@example.com"
+#   alarms:
+#     ecs_cpu_threshold: 90
+#     ecs_memory_threshold: 90

--- a/src/ecs_stack.py
+++ b/src/ecs_stack.py
@@ -32,7 +32,9 @@ class EcsStack(cdk.Stack):
                 name=namespace,
                 use_for_service_connect=True,
             ),
-            container_insights_v2=ecs.ContainerInsights.ENHANCED
-            if container_insights
-            else ecs.ContainerInsights.DISABLED,
+            container_insights_v2=(
+                ecs.ContainerInsights.ENHANCED
+                if container_insights
+                else ecs.ContainerInsights.DISABLED
+            ),
         )

--- a/src/ecs_stack.py
+++ b/src/ecs_stack.py
@@ -19,7 +19,8 @@ class EcsStack(cdk.Stack):
         construct_id: str,
         vpc: ec2.Vpc,
         namespace: str,
-        **kwargs
+        container_insights: bool = False,
+        **kwargs,
     ) -> None:
         super().__init__(scope, construct_id, **kwargs)
 
@@ -31,4 +32,7 @@ class EcsStack(cdk.Stack):
                 name=namespace,
                 use_for_service_connect=True,
             ),
+            container_insights_v2=ecs.ContainerInsights.ENHANCED
+            if container_insights
+            else ecs.ContainerInsights.DISABLED,
         )

--- a/src/monitoring_stack.py
+++ b/src/monitoring_stack.py
@@ -28,8 +28,8 @@ class MonitoringStack(cdk.Stack):
     Optional monitoring stack that creates CloudWatch alarms, an SNS notification
     topic, and an optional CloudWatch dashboard for ECS services.
 
-    This stack is opt-in: it is only created when MONITORING.notification_email
-    is set in the environment config.
+    This stack is opt-in: it is only created when MONITORING.enabled is true
+    in the environment config.
     """
 
     def __init__(

--- a/src/monitoring_stack.py
+++ b/src/monitoring_stack.py
@@ -1,0 +1,401 @@
+import json
+from typing import Any, Dict
+
+import aws_cdk as cdk
+from aws_cdk import aws_cloudwatch as cw
+from aws_cdk import aws_cloudwatch_actions as cw_actions
+from aws_cdk import aws_ecs as ecs
+from aws_cdk import aws_elasticloadbalancingv2 as elbv2
+from aws_cdk import aws_lambda as lambda_
+from aws_cdk import aws_sns as sns
+from aws_cdk import aws_sns_subscriptions as subs
+from constructs import Construct
+
+# Default alarm thresholds applied when not specified in config
+_DEFAULT_ALARMS = {
+    "ecs_cpu_threshold": 80,
+    "ecs_memory_threshold": 80,
+    "alb_5xx_threshold": 10,
+    "alb_p99_latency_threshold": 5,
+    "unhealthy_host_threshold": 1,
+    "healthy_host_min": 1,
+    "running_task_min": 1,
+}
+
+
+class MonitoringStack(cdk.Stack):
+    """
+    Optional monitoring stack that creates CloudWatch alarms, an SNS notification
+    topic, and an optional CloudWatch dashboard for ECS services.
+
+    This stack is opt-in: it is only created when MONITORING.notification_email
+    is set in the environment config.
+    """
+
+    def __init__(
+        self,
+        scope: Construct,
+        construct_id: str,
+        service: ecs.FargateService,
+        cluster: ecs.Cluster,
+        load_balancer: elbv2.ApplicationLoadBalancer,
+        target_group: elbv2.ApplicationTargetGroup,
+        monitoring_config: Dict[str, Any],
+        **kwargs,
+    ) -> None:
+        super().__init__(scope, construct_id, **kwargs)
+
+        alarm_config = {**_DEFAULT_ALARMS, **monitoring_config.get("alarms", {})}
+        notification_email = monitoring_config["notification_email"]
+        slack_webhook_url = monitoring_config.get("slack_webhook_url", "")
+        enable_dashboard = monitoring_config.get("enable_dashboard", True)
+
+        # ------------------------------------------------------------------ #
+        # SNS Topic + Subscriptions
+        # ------------------------------------------------------------------ #
+        self.alarm_topic = sns.Topic(
+            self, "AlarmTopic", display_name=f"{construct_id}-alarms"
+        )
+
+        self.alarm_topic.add_subscription(
+            subs.EmailSubscription(notification_email)
+        )
+
+        if slack_webhook_url:
+            slack_handler = lambda_.Function(
+                self,
+                "SlackNotifier",
+                runtime=lambda_.Runtime.PYTHON_3_12,
+                handler="index.handler",
+                code=lambda_.Code.from_inline(
+                    _slack_lambda_code(slack_webhook_url)
+                ),
+                timeout=cdk.Duration.seconds(10),
+            )
+            self.alarm_topic.add_subscription(
+                subs.LambdaSubscription(slack_handler)
+            )
+
+        cdk.CfnOutput(
+            self,
+            "AlarmTopicArn",
+            value=self.alarm_topic.topic_arn,
+            description="SNS topic ARN for alarm notifications",
+        )
+
+        alarm_action = cw_actions.SnsAction(self.alarm_topic)
+
+        # ------------------------------------------------------------------ #
+        # CloudWatch Alarms
+        # ------------------------------------------------------------------ #
+        cpu_alarm = cw.Alarm(
+            self,
+            "EcsCpuHigh",
+            metric=service.metric_cpu_utilization(
+                period=cdk.Duration.minutes(1),
+                statistic="Average",
+            ),
+            threshold=alarm_config["ecs_cpu_threshold"],
+            evaluation_periods=3,
+            datapoints_to_alarm=2,
+            comparison_operator=cw.ComparisonOperator.GREATER_THAN_OR_EQUAL_TO_THRESHOLD,
+            alarm_description="ECS service CPU utilization is high",
+            treat_missing_data=cw.TreatMissingData.NOT_BREACHING,
+        )
+        cpu_alarm.add_alarm_action(alarm_action)
+        cpu_alarm.add_ok_action(alarm_action)
+
+        memory_alarm = cw.Alarm(
+            self,
+            "EcsMemoryHigh",
+            metric=service.metric_memory_utilization(
+                period=cdk.Duration.minutes(1),
+                statistic="Average",
+            ),
+            threshold=alarm_config["ecs_memory_threshold"],
+            evaluation_periods=3,
+            datapoints_to_alarm=2,
+            comparison_operator=cw.ComparisonOperator.GREATER_THAN_OR_EQUAL_TO_THRESHOLD,
+            alarm_description="ECS service memory utilization is high — risk of OOM",
+            treat_missing_data=cw.TreatMissingData.NOT_BREACHING,
+        )
+        memory_alarm.add_alarm_action(alarm_action)
+        memory_alarm.add_ok_action(alarm_action)
+
+        error_5xx_alarm = cw.Alarm(
+            self,
+            "Alb5xxErrors",
+            metric=load_balancer.metric_http_code_elb(
+                code=elbv2.HttpCodeElb.ELB_5XX_COUNT,
+                period=cdk.Duration.minutes(5),
+                statistic="Sum",
+            ),
+            threshold=alarm_config["alb_5xx_threshold"],
+            evaluation_periods=1,
+            comparison_operator=cw.ComparisonOperator.GREATER_THAN_OR_EQUAL_TO_THRESHOLD,
+            alarm_description="ALB is returning elevated 5xx errors",
+            treat_missing_data=cw.TreatMissingData.NOT_BREACHING,
+        )
+        error_5xx_alarm.add_alarm_action(alarm_action)
+        error_5xx_alarm.add_ok_action(alarm_action)
+
+        p99_alarm = cw.Alarm(
+            self,
+            "AlbP99Latency",
+            metric=load_balancer.metric_target_response_time(
+                period=cdk.Duration.minutes(1),
+                statistic="p99",
+            ),
+            threshold=alarm_config["alb_p99_latency_threshold"],
+            evaluation_periods=3,
+            datapoints_to_alarm=2,
+            comparison_operator=cw.ComparisonOperator.GREATER_THAN_OR_EQUAL_TO_THRESHOLD,
+            alarm_description="ALB P99 target response time is high",
+            treat_missing_data=cw.TreatMissingData.NOT_BREACHING,
+        )
+        p99_alarm.add_alarm_action(alarm_action)
+        p99_alarm.add_ok_action(alarm_action)
+
+        unhealthy_alarm = cw.Alarm(
+            self,
+            "UnhealthyHosts",
+            metric=target_group.metric_unhealthy_host_count(
+                period=cdk.Duration.minutes(1),
+                statistic="Maximum",
+            ),
+            threshold=alarm_config["unhealthy_host_threshold"],
+            evaluation_periods=2,
+            datapoints_to_alarm=2,
+            comparison_operator=cw.ComparisonOperator.GREATER_THAN_OR_EQUAL_TO_THRESHOLD,
+            alarm_description="ALB target group has unhealthy hosts",
+            treat_missing_data=cw.TreatMissingData.NOT_BREACHING,
+        )
+        unhealthy_alarm.add_alarm_action(alarm_action)
+        unhealthy_alarm.add_ok_action(alarm_action)
+
+        healthy_alarm = cw.Alarm(
+            self,
+            "HealthyHostsLow",
+            metric=target_group.metric_healthy_host_count(
+                period=cdk.Duration.minutes(1),
+                statistic="Minimum",
+            ),
+            threshold=alarm_config["healthy_host_min"],
+            evaluation_periods=1,
+            comparison_operator=cw.ComparisonOperator.LESS_THAN_THRESHOLD,
+            alarm_description="ALB target group has fewer healthy hosts than expected",
+            treat_missing_data=cw.TreatMissingData.BREACHING,
+        )
+        healthy_alarm.add_alarm_action(alarm_action)
+        healthy_alarm.add_ok_action(alarm_action)
+
+        running_tasks_alarm = cw.Alarm(
+            self,
+            "RunningTasksZero",
+            metric=cw.Metric(
+                namespace="ECS/ContainerInsights",
+                metric_name="RunningTaskCount",
+                dimensions_map={
+                    "ClusterName": cluster.cluster_name,
+                    "ServiceName": service.service_name,
+                },
+                period=cdk.Duration.minutes(1),
+                statistic="Minimum",
+            ),
+            threshold=alarm_config["running_task_min"],
+            evaluation_periods=1,
+            comparison_operator=cw.ComparisonOperator.LESS_THAN_THRESHOLD,
+            alarm_description="ECS service has no running tasks — service is down",
+            treat_missing_data=cw.TreatMissingData.BREACHING,
+        )
+        running_tasks_alarm.add_alarm_action(alarm_action)
+        running_tasks_alarm.add_ok_action(alarm_action)
+
+        # ------------------------------------------------------------------ #
+        # CloudWatch Dashboard (optional)
+        # ------------------------------------------------------------------ #
+        if enable_dashboard:
+            dashboard = cw.Dashboard(
+                self,
+                "Dashboard",
+                dashboard_name=f"{construct_id}-overview",
+                default_interval=cdk.Duration.hours(3),
+            )
+
+            # -- ECS Service section --
+            dashboard.add_widgets(
+                cw.TextWidget(
+                    markdown="# ECS Service", width=24, height=1
+                )
+            )
+            dashboard.add_widgets(
+                cw.GraphWidget(
+                    title="CPU Utilization (%)",
+                    left=[
+                        service.metric_cpu_utilization(
+                            statistic="Average",
+                            period=cdk.Duration.minutes(1),
+                        )
+                    ],
+                    width=8,
+                ),
+                cw.GraphWidget(
+                    title="Memory Utilization (%)",
+                    left=[
+                        service.metric_memory_utilization(
+                            statistic="Average",
+                            period=cdk.Duration.minutes(1),
+                        )
+                    ],
+                    width=8,
+                ),
+                cw.GraphWidget(
+                    title="Running Task Count",
+                    left=[
+                        cw.Metric(
+                            namespace="ECS/ContainerInsights",
+                            metric_name="RunningTaskCount",
+                            dimensions_map={
+                                "ClusterName": cluster.cluster_name,
+                                "ServiceName": service.service_name,
+                            },
+                            period=cdk.Duration.minutes(1),
+                            statistic="Average",
+                            label="Running Tasks",
+                        )
+                    ],
+                    width=8,
+                ),
+            )
+
+            # -- Load Balancer section --
+            dashboard.add_widgets(
+                cw.TextWidget(
+                    markdown="# Load Balancer", width=24, height=1
+                )
+            )
+            dashboard.add_widgets(
+                cw.GraphWidget(
+                    title="Requests & Errors",
+                    left=[
+                        load_balancer.metric_request_count(
+                            statistic="Sum",
+                            label="Requests",
+                            period=cdk.Duration.minutes(1),
+                        )
+                    ],
+                    right=[
+                        load_balancer.metric_http_code_elb(
+                            code=elbv2.HttpCodeElb.ELB_4XX_COUNT,
+                            statistic="Sum",
+                            label="4XX",
+                            period=cdk.Duration.minutes(1),
+                        ),
+                        load_balancer.metric_http_code_elb(
+                            code=elbv2.HttpCodeElb.ELB_5XX_COUNT,
+                            statistic="Sum",
+                            label="5XX",
+                            period=cdk.Duration.minutes(1),
+                        ),
+                    ],
+                    width=12,
+                ),
+                cw.GraphWidget(
+                    title="Target Response Time",
+                    left=[
+                        load_balancer.metric_target_response_time(
+                            statistic="p50",
+                            label="p50",
+                            period=cdk.Duration.minutes(1),
+                        ),
+                        load_balancer.metric_target_response_time(
+                            statistic="p90",
+                            label="p90",
+                            period=cdk.Duration.minutes(1),
+                        ),
+                        load_balancer.metric_target_response_time(
+                            statistic="p99",
+                            label="p99",
+                            period=cdk.Duration.minutes(1),
+                        ),
+                    ],
+                    width=12,
+                ),
+            )
+
+            # -- Health section --
+            dashboard.add_widgets(
+                cw.TextWidget(
+                    markdown="# Health", width=24, height=1
+                )
+            )
+            dashboard.add_widgets(
+                cw.GraphWidget(
+                    title="Host Health",
+                    left=[
+                        target_group.metric_healthy_host_count(
+                            statistic="Average",
+                            label="Healthy",
+                            period=cdk.Duration.minutes(1),
+                        ),
+                        target_group.metric_unhealthy_host_count(
+                            statistic="Average",
+                            label="Unhealthy",
+                            period=cdk.Duration.minutes(1),
+                        ),
+                    ],
+                    width=8,
+                ),
+                cw.GraphWidget(
+                    title="Active Connections",
+                    left=[
+                        load_balancer.metric_active_connection_count(
+                            statistic="Sum",
+                            label="Active",
+                            period=cdk.Duration.minutes(1),
+                        )
+                    ],
+                    width=8,
+                ),
+                cw.AlarmWidget(
+                    title="Running Tasks (alarm if zero)",
+                    alarm=running_tasks_alarm,
+                    width=8,
+                ),
+            )
+
+            dashboard_url = (
+                f"https://{self.region}.console.aws.amazon.com"
+                f"/cloudwatch/home#dashboards:name={construct_id}-overview"
+            )
+            cdk.CfnOutput(
+                self,
+                "DashboardUrl",
+                value=dashboard_url,
+                description="CloudWatch dashboard URL",
+            )
+
+
+def _slack_lambda_code(webhook_url: str) -> str:
+    """Return inline Python code for a Lambda that posts SNS messages to Slack."""
+    safe_url = json.dumps(webhook_url)
+    return f"""\
+import json
+import urllib.request
+
+WEBHOOK_URL = {safe_url}
+
+def handler(event, context):
+    for record in event["Records"]:
+        sns_message = record["Sns"]
+        payload = json.dumps({{
+            "text": f"*{{sns_message['Subject']}}*\\n{{sns_message['Message']}}"
+        }}).encode("utf-8")
+        req = urllib.request.Request(
+            WEBHOOK_URL,
+            data=payload,
+            headers={{"Content-Type": "application/json"}},
+        )
+        urllib.request.urlopen(req)
+    return {{"statusCode": 200}}
+"""

--- a/src/monitoring_stack.py
+++ b/src/monitoring_stack.py
@@ -57,9 +57,7 @@ class MonitoringStack(cdk.Stack):
             self, "AlarmTopic", display_name=f"{construct_id}-alarms"
         )
 
-        self.alarm_topic.add_subscription(
-            subs.EmailSubscription(notification_email)
-        )
+        self.alarm_topic.add_subscription(subs.EmailSubscription(notification_email))
 
         if slack_webhook_url:
             slack_handler = lambda_.Function(
@@ -67,14 +65,10 @@ class MonitoringStack(cdk.Stack):
                 "SlackNotifier",
                 runtime=lambda_.Runtime.PYTHON_3_12,
                 handler="index.handler",
-                code=lambda_.Code.from_inline(
-                    _slack_lambda_code(slack_webhook_url)
-                ),
+                code=lambda_.Code.from_inline(_slack_lambda_code(slack_webhook_url)),
                 timeout=cdk.Duration.seconds(10),
             )
-            self.alarm_topic.add_subscription(
-                subs.LambdaSubscription(slack_handler)
-            )
+            self.alarm_topic.add_subscription(subs.LambdaSubscription(slack_handler))
 
         cdk.CfnOutput(
             self,
@@ -224,9 +218,7 @@ class MonitoringStack(cdk.Stack):
 
             # -- ECS Service section --
             dashboard.add_widgets(
-                cw.TextWidget(
-                    markdown="# ECS Service", width=24, height=1
-                )
+                cw.TextWidget(markdown="# ECS Service", width=24, height=1)
             )
             dashboard.add_widgets(
                 cw.GraphWidget(
@@ -270,9 +262,7 @@ class MonitoringStack(cdk.Stack):
 
             # -- Load Balancer section --
             dashboard.add_widgets(
-                cw.TextWidget(
-                    markdown="# Load Balancer", width=24, height=1
-                )
+                cw.TextWidget(markdown="# Load Balancer", width=24, height=1)
             )
             dashboard.add_widgets(
                 cw.GraphWidget(
@@ -325,9 +315,7 @@ class MonitoringStack(cdk.Stack):
 
             # -- Health section --
             dashboard.add_widgets(
-                cw.TextWidget(
-                    markdown="# Health", width=24, height=1
-                )
+                cw.TextWidget(markdown="# Health", width=24, height=1)
             )
             dashboard.add_widgets(
                 cw.GraphWidget(

--- a/src/service_stack.py
+++ b/src/service_stack.py
@@ -256,7 +256,7 @@ class LoadBalancedServiceStack(ServiceStack):
                 certificates=[self.cert],
             )
 
-            https_listener.add_targets(
+            self.target_group = https_listener.add_targets(
                 "HttpsTarget",
                 port=props.container_port,
                 protocol=elbv2.ApplicationProtocol.HTTP,
@@ -298,7 +298,7 @@ class LoadBalancedServiceStack(ServiceStack):
                 protocol=elbv2.ApplicationProtocol.HTTP,
             )
 
-            http_listener.add_targets(
+            self.target_group = http_listener.add_targets(
                 "HttpTarget",
                 port=props.container_port,
                 protocol=elbv2.ApplicationProtocol.HTTP,

--- a/src/utils.py
+++ b/src/utils.py
@@ -4,6 +4,17 @@ from pathlib import Path
 from typing import Any, Dict
 
 
+def _deep_merge(base: dict, override: dict) -> dict:
+    """Recursively merge override into base, returning a new dict."""
+    result = base.copy()
+    for key, value in override.items():
+        if key in result and isinstance(result[key], dict) and isinstance(value, dict):
+            result[key] = _deep_merge(result[key], value)
+        else:
+            result[key] = value
+    return result
+
+
 def load_context_config(env_name: str, config_dir: str = "config") -> Dict[str, Any]:
     """
     Load AWS CDK context configuration from a YAML or JSON file.
@@ -64,6 +75,6 @@ def load_context_config(env_name: str, config_dir: str = "config") -> Dict[str, 
 
     # Load and merge configs
     env_config = read_file(env_files[0])
-    merged_config = {**base_config, **env_config}
+    merged_config = _deep_merge(base_config, env_config)
 
     return merged_config

--- a/tests/unit/test_monitoring_stack.py
+++ b/tests/unit/test_monitoring_stack.py
@@ -13,6 +13,7 @@ def _create_monitoring_template(monitoring_config=None):
     """Helper to create a MonitoringStack and return its synthesized template."""
     if monitoring_config is None:
         monitoring_config = {
+            "enabled": True,
             "notification_email": "test@example.com",
         }
 
@@ -77,6 +78,7 @@ def test_monitoring_stack_creates_dashboard_by_default():
 def test_monitoring_stack_no_dashboard_when_disabled():
     template = _create_monitoring_template(
         monitoring_config={
+            "enabled": True,
             "notification_email": "test@example.com",
             "enable_dashboard": False,
         }
@@ -87,6 +89,7 @@ def test_monitoring_stack_no_dashboard_when_disabled():
 def test_monitoring_stack_custom_cpu_threshold():
     template = _create_monitoring_template(
         monitoring_config={
+            "enabled": True,
             "notification_email": "test@example.com",
             "alarms": {"ecs_cpu_threshold": 70},
         }
@@ -108,6 +111,7 @@ def test_monitoring_stack_no_slack_lambda_without_webhook():
 def test_monitoring_stack_creates_slack_lambda_with_webhook():
     template = _create_monitoring_template(
         monitoring_config={
+            "enabled": True,
             "notification_email": "test@example.com",
             "slack_webhook_url": "https://hooks.slack.com/services/T/B/x",
         }

--- a/tests/unit/test_monitoring_stack.py
+++ b/tests/unit/test_monitoring_stack.py
@@ -18,7 +18,9 @@ def _create_monitoring_template(monitoring_config=None):
 
     app = cdk.App()
     network = NetworkStack(app, "Net", vpc_cidr="10.0.0.0/24")
-    ecs = EcsStack(app, "Ecs", vpc=network.vpc, namespace="test.io", container_insights=True)
+    ecs = EcsStack(
+        app, "Ecs", vpc=network.vpc, namespace="test.io", container_insights=True
+    )
     lb = LoadBalancerStack(app, "Lb", vpc=network.vpc)
 
     props = ServiceProps(

--- a/tests/unit/test_monitoring_stack.py
+++ b/tests/unit/test_monitoring_stack.py
@@ -1,0 +1,119 @@
+import aws_cdk as cdk
+import aws_cdk.assertions as assertions
+
+from src.ecs_stack import EcsStack
+from src.load_balancer_stack import LoadBalancerStack
+from src.monitoring_stack import MonitoringStack
+from src.network_stack import NetworkStack
+from src.service_props import ServiceProps
+from src.service_stack import LoadBalancedServiceStack
+
+
+def _create_monitoring_template(monitoring_config=None):
+    """Helper to create a MonitoringStack and return its synthesized template."""
+    if monitoring_config is None:
+        monitoring_config = {
+            "notification_email": "test@example.com",
+        }
+
+    app = cdk.App()
+    network = NetworkStack(app, "Net", vpc_cidr="10.0.0.0/24")
+    ecs = EcsStack(app, "Ecs", vpc=network.vpc, namespace="test.io", container_insights=True)
+    lb = LoadBalancerStack(app, "Lb", vpc=network.vpc)
+
+    props = ServiceProps(
+        container_name="test-app",
+        container_location="nginx:latest",
+        container_port=80,
+        ecs_task_cpu=256,
+        ecs_task_memory=512,
+    )
+    svc = LoadBalancedServiceStack(
+        app,
+        "Svc",
+        vpc=network.vpc,
+        cluster=ecs.cluster,
+        props=props,
+        load_balancer=lb.alb,
+    )
+
+    monitoring = MonitoringStack(
+        app,
+        "Mon",
+        service=svc.service,
+        cluster=ecs.cluster,
+        load_balancer=lb.alb,
+        target_group=svc.target_group,
+        monitoring_config=monitoring_config,
+    )
+    return assertions.Template.from_stack(monitoring)
+
+
+def test_monitoring_stack_creates_sns_topic():
+    template = _create_monitoring_template()
+    template.resource_count_is("AWS::SNS::Topic", 1)
+
+
+def test_monitoring_stack_creates_email_subscription():
+    template = _create_monitoring_template()
+    template.has_resource_properties(
+        "AWS::SNS::Subscription",
+        {"Protocol": "email", "Endpoint": "test@example.com"},
+    )
+
+
+def test_monitoring_stack_creates_all_alarms():
+    template = _create_monitoring_template()
+    template.resource_count_is("AWS::CloudWatch::Alarm", 7)
+
+
+def test_monitoring_stack_creates_dashboard_by_default():
+    template = _create_monitoring_template()
+    template.resource_count_is("AWS::CloudWatch::Dashboard", 1)
+
+
+def test_monitoring_stack_no_dashboard_when_disabled():
+    template = _create_monitoring_template(
+        monitoring_config={
+            "notification_email": "test@example.com",
+            "enable_dashboard": False,
+        }
+    )
+    template.resource_count_is("AWS::CloudWatch::Dashboard", 0)
+
+
+def test_monitoring_stack_custom_cpu_threshold():
+    template = _create_monitoring_template(
+        monitoring_config={
+            "notification_email": "test@example.com",
+            "alarms": {"ecs_cpu_threshold": 70},
+        }
+    )
+    template.has_resource_properties(
+        "AWS::CloudWatch::Alarm",
+        {
+            "Threshold": 70,
+            "MetricName": "CPUUtilization",
+        },
+    )
+
+
+def test_monitoring_stack_no_slack_lambda_without_webhook():
+    template = _create_monitoring_template()
+    template.resource_count_is("AWS::Lambda::Function", 0)
+
+
+def test_monitoring_stack_creates_slack_lambda_with_webhook():
+    template = _create_monitoring_template(
+        monitoring_config={
+            "notification_email": "test@example.com",
+            "slack_webhook_url": "https://hooks.slack.com/services/T/B/x",
+        }
+    )
+    template.resource_count_is("AWS::Lambda::Function", 1)
+
+
+def test_monitoring_stack_exports_topic_arn():
+    template = _create_monitoring_template()
+    outputs = template.find_outputs("*")
+    assert any("AlarmTopicArn" in key for key in outputs)

--- a/tests/unit/test_utils.py
+++ b/tests/unit/test_utils.py
@@ -4,7 +4,58 @@ import tempfile
 import yaml
 from pathlib import Path
 
-from src.utils import load_context_config
+from src.utils import _deep_merge, load_context_config
+
+
+class TestDeepMerge:
+    """Test suite for the _deep_merge function."""
+
+    def test_flat_merge(self):
+        """Test merging flat dicts behaves like shallow merge."""
+        base = {"a": 1, "b": 2}
+        override = {"b": 3, "c": 4}
+        assert _deep_merge(base, override) == {"a": 1, "b": 3, "c": 4}
+
+    def test_nested_merge_preserves_base_keys(self):
+        """Test that nested override only replaces specified keys."""
+        base = {
+            "MONITORING": {
+                "notification_email": "",
+                "alarms": {
+                    "ecs_cpu_threshold": 80,
+                    "ecs_memory_threshold": 80,
+                },
+            }
+        }
+        override = {
+            "MONITORING": {
+                "notification_email": "team@example.com",
+            }
+        }
+        result = _deep_merge(base, override)
+        assert result["MONITORING"]["notification_email"] == "team@example.com"
+        assert result["MONITORING"]["alarms"]["ecs_cpu_threshold"] == 80
+        assert result["MONITORING"]["alarms"]["ecs_memory_threshold"] == 80
+
+    def test_nested_merge_overrides_specific_keys(self):
+        """Test that specific nested keys can be overridden."""
+        base = {"alarms": {"cpu": 80, "memory": 80}}
+        override = {"alarms": {"cpu": 70}}
+        result = _deep_merge(base, override)
+        assert result == {"alarms": {"cpu": 70, "memory": 80}}
+
+    def test_does_not_mutate_base(self):
+        """Test that the base dict is not modified."""
+        base = {"a": {"b": 1}}
+        override = {"a": {"b": 2}}
+        _deep_merge(base, override)
+        assert base == {"a": {"b": 1}}
+
+    def test_override_dict_with_non_dict(self):
+        """Test that a non-dict value replaces a dict value."""
+        base = {"a": {"b": 1}}
+        override = {"a": "string"}
+        assert _deep_merge(base, override) == {"a": "string"}
 
 
 class TestLoadContextConfig:
@@ -145,6 +196,32 @@ class TestLoadContextConfig:
             }
 
             assert result == expected
+
+    def test_base_config_deep_merging(self):
+        """Test that nested dicts in base.yaml are deep-merged with env config."""
+        with tempfile.TemporaryDirectory() as temp_dir:
+            base_file = Path(temp_dir) / "base.yaml"
+            base_config = {
+                "MONITORING": {
+                    "notification_email": "",
+                    "alarms": {"ecs_cpu_threshold": 80, "ecs_memory_threshold": 80},
+                }
+            }
+            with open(base_file, "w") as f:
+                yaml.dump(base_config, f)
+
+            env_file = Path(temp_dir) / "dev.yaml"
+            env_config = {
+                "FQDN": "dev.example.com",
+                "MONITORING": {"notification_email": "team@example.com"},
+            }
+            with open(env_file, "w") as f:
+                yaml.dump(env_config, f)
+
+            result = load_context_config("dev", temp_dir)
+            assert result["FQDN"] == "dev.example.com"
+            assert result["MONITORING"]["notification_email"] == "team@example.com"
+            assert result["MONITORING"]["alarms"]["ecs_cpu_threshold"] == 80
 
     def test_no_base_config(self):
         """Test loading config when base.yaml doesn't exist."""


### PR DESCRIPTION
https://sagebionetworks.jira.com/browse/IT-4961

## Why

Our MCP server was running out of memory on ECS and nobody knew — there was no monitoring or alerting in place. Any service deployed with this template today has CloudWatch Logs but zero alarms, zero dashboards, and zero notifications. When something goes wrong (OOM, service down, elevated errors), the team only finds out when users report it.

This change adds monitoring as a first-class, opt-in feature of the template so that any team cloning it can get production-grade observability by adding 2 lines of YAML config.

## What

**New `MonitoringStack`** (`src/monitoring_stack.py`) — a fifth CDK stack that creates:

- **SNS topic** with email subscription (+ optional Slack notifications via an inline Lambda)
- **7 CloudWatch alarms** covering the critical failure modes for an ECS/ALB deployment:
  | Alarm | Default Threshold | Why it matters |
  |-------|-------------------|----------------|
  | ECS CPU High | ≥ 80% | Approaching resource limits |
  | ECS Memory High | ≥ 80% | OOM precursor — the exact problem that prompted this |
  | ALB 5xx Errors | ≥ 10/5min | Backend is failing |
  | ALB P99 Latency | ≥ 5s | User-facing performance degradation |
  | Unhealthy Hosts | ≥ 1 | Container health checks failing |
  | Healthy Hosts Low | < 1 | No healthy targets — service effectively down |
  | Running Tasks Zero | < 1 | Service is completely down |

- **CloudWatch dashboard** (optional, on by default) with ECS metrics, ALB metrics, and health widgets

**Supporting changes:**
- `src/utils.py` — Added deep merge so environment YAML can override individual nested keys (e.g., one alarm threshold) without losing the rest
- `src/ecs_stack.py` — Enables ECS Container Insights (Enhanced) when monitoring is active, required for the RunningTaskCount metric
- `src/service_stack.py` — Exposes `self.target_group` from `LoadBalancedServiceStack` for healthy/unhealthy host metrics
- `app.py` — Wires in MonitoringStack, gated on `MONITORING.notification_email` being set
- `config/*.yaml` — Commented-out MONITORING examples in all environment configs
- `README.md` — Full documentation with mermaid architecture/sequence diagrams

## How to use

The monitoring stack is **completely opt-in**. Without config changes, the template behaves identically to before — zero new resources, zero cost.

To enable, uncomment and set `notification_email` in your environment YAML:

```yaml
# config/dev.yaml
MONITORING:
  notification_email: "team@example.com"
```

That's it. This creates all 7 alarms, the SNS topic with email subscription, the dashboard, and enables Container Insights. After deploying, confirm the SNS subscription via the email you receive.

All alarm thresholds are individually overridable per environment:

```yaml
# config/prod.yaml — tighter thresholds for production
MONITORING:
  notification_email: "oncall@example.com"
  slack_webhook_url: "https://hooks.slack.com/services/T.../B.../..."
  alarms:
    ecs_cpu_threshold: 70
    ecs_memory_threshold: 70
```

## Test plan

- [ ] `python -m pytest tests/` — 40 tests pass (9 new monitoring tests, 6 new deep merge tests)
- [ ] `cdk synth -c env=dev` — synthesizes successfully with 4 stacks (no monitoring config = no monitoring stack)
- [ ] Enable MONITORING in dev.yaml and verify `cdk synth` produces 5 stacks including `app-dev-monitoring`
- [ ] Review synthesized CloudFormation for correct alarm thresholds, SNS subscriptions, dashboard JSON
- [ ] Deploy to dev, confirm SNS email subscription, verify alarms and dashboard appear in CloudWatch console